### PR TITLE
feat: react-router

### DIFF
--- a/hyo/frontend/project/package-lock.json
+++ b/hyo/frontend/project/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router": "^7.7.0",
         "tailwindcss": "^4.1.11"
       },
       "devDependencies": {
@@ -2162,6 +2163,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3439,6 +3449,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.0.tgz",
+      "integrity": "sha512-3FUYSwlvB/5wRJVTL/aavqHmfUKe0+Xm9MllkYgGo9eDwNdkvwlJGjpPxono1kCycLt6AnDTgjmXvK3/B4QGuw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3538,6 +3570,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/hyo/frontend/project/package.json
+++ b/hyo/frontend/project/package.json
@@ -3,11 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  
   "engines": {
     "node": "24.4.0"
   },
-
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
@@ -18,6 +16,7 @@
     "@tailwindcss/vite": "^4.1.11",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router": "^7.7.0",
     "tailwindcss": "^4.1.11"
   },
   "devDependencies": {

--- a/hyo/frontend/project/src/main.tsx
+++ b/hyo/frontend/project/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
+
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import { RouterProvider } from 'react-router'
+import router from './router/root.tsx'
+
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+  <RouterProvider router={router}></RouterProvider>,
 )

--- a/hyo/frontend/project/src/pages/aboutPage.tsx
+++ b/hyo/frontend/project/src/pages/aboutPage.tsx
@@ -1,0 +1,14 @@
+import { NavLink } from "react-router";
+
+function AboutPage() {
+    return ( 
+        <div className="text-3xl">
+            <div className="flex">
+                <NavLink to="/">Main</NavLink>
+            </div>
+            <h1>About Page</h1>
+        </div>
+     );
+}
+
+export default AboutPage;

--- a/hyo/frontend/project/src/pages/mainPage.tsx
+++ b/hyo/frontend/project/src/pages/mainPage.tsx
@@ -1,0 +1,17 @@
+//tsx 와 ts
+//tsx는 리액트 컴포넌트를 작성할 때 사용하고, ts는 일반적인 타입스크립트 파일입니다.
+
+import { NavLink } from "react-router";
+
+function MainPage() {
+    return ( 
+        <div className="text-3xl">
+            <div className="flex">
+                <NavLink to="/about">About</NavLink>
+            </div>
+            <div> Main Page</div>
+        </div>
+     );
+}
+
+export default MainPage;

--- a/hyo/frontend/project/src/router/root.tsx
+++ b/hyo/frontend/project/src/router/root.tsx
@@ -1,0 +1,31 @@
+import { createBrowserRouter } from "react-router";
+
+
+// 로딩 컴포넌트
+import { lazy, Suspense } from "react";
+const Loading = () => <div>Loading...</div>;
+
+// lazy?
+// 전부다 로딩하면 느림 => 호출전까지 부르지 않게 설정
+const Main = lazy(() => import("../pages/mainPage"));
+const About = lazy(()=> import("../pages/aboutPage"));
+
+
+const MainPage = lazy(() => import("../pages/mainPage"));
+
+// suspense = 불러오는 동안 무엇을 할건지 정할 수 잇음
+const router = createBrowserRouter([
+  {
+    path: "",
+    // 메인 페이지 호출 시 로딩하다가 MainPage를 불러옴
+    element: <Suspense fallback={<Loading />}> <Main/> </Suspense>,
+  },
+// 새로고침이 무섭다?
+// 기존 페이지 main에서 about으로 옴 -> 새로고침하면 main이 네트워크에서 없어짐
+  {
+    path: "about",
+    element: (<Suspense fallback={<Loading />}><About /></Suspense>),
+  },
+])
+
+export default router;


### PR DESCRIPTION
### 타입스크립트
- 자바스크립트 + 타입 시스템을 추가함 = 코드 작성에 규칙이 생김
  - 컴파일 시점에서 오류를 잡아줌 -> 오류를 미리 해결할 수 있음
- 컴파일 시 다시 변환하는 작업을 거쳐서 자바스크립트형태로 컴파일

### 리액트
- SPA의 최초 로딩시간이 길다는 단점을 극복하는 방법이 있음
  - lazy = 사용 시에만 불러옴 -> 한 번에 다 부르지 않음 -> 최초 로딩 빠름
  -  suspense = 페이지가 넘어가는 짧은 순간이지만 인터넷 속도는 환경에 따라 다르고 어떻게 될지 모름 -> 넘어가는 순간에 loading페이지로 보내서 사용자 경험을 개선함
- 새로고침의 위험성?
  - 새로고침을 하게 되면 기존 페이지 요청을 다시함
  - lazy로 페이지들을 설정함 -> 실제 필요한 순간에 가져올 수 있음
  - `root.tsx`에 `createBrowserRouter`안에 불러오도록 되어있음 
  - 개발환경에서는 SPA의 라우팅이 다시 시작되어 index.html -> main.tsx -> root.tsx 순으로 `createBrowserRouter`를 부르기 때문에 문제는 없다.
  - 배포 단계에서는 모든 경로 요청에 대해 `index.html`을 부르는 설정이 없다면 404 에러가 발생할 수 있음